### PR TITLE
Fix error /usr/bin/env: ‘node -r esm’: No such file or directory

### DIFF
--- a/bin/server
+++ b/bin/server
@@ -1,4 +1,4 @@
-#!/usr/bin/env node -r esm
+#!/usr/bin/env -S node -r esm
 
 import 'localenv';
 import optimist from 'optimist';


### PR DESCRIPTION
env -S was needed to pass options in shebang lines as shown in the error below:
/usr/bin/env: ‘node -r esm’: No such file or directory
/usr/bin/env: use -[v]S to pass options in shebang lines